### PR TITLE
Updated spec constant proposal to use NTTP.

### DIFF
--- a/proposals/sycl_kernel_handler.md
+++ b/proposals/sycl_kernel_handler.md
@@ -1,0 +1,94 @@
+# SYCL kernel_handle
+
+|                  |                                        |
+| ---------------- | ---------------------------------------|
+| Name             | kernel_handle                          |
+| Date of creation | 17th Feb 2020                          |
+| Last updated     | 17th Feb 2020                          |
+| Status           | WIP                                    |
+| Current revision | 1                                      |
+| Available        | N/A                                    |
+| Reply-to         | Victor Lomuller <victor@codeplay.com>  |
+| Original author  | Victor Lomuller <victor@codeplay.com>  |
+| Contributors     | TBD |
+
+## Overview
+
+The library implementation of certain device features require the use of a device side handler.
+This proposal introduces a `kernel_handler` to provide access to extra device capabilities implementable as a library.
+
+## Motivation
+
+The initial proposal of specialization constant forced the user to explicitly get individual `specialization_constant` objects that needed to be propagated in the final program.
+
+Using a handler, the user has only 1 object to carry to access `specialization_constant` objects thus simplifying the interface.
+
+For now, the proposal is limited to support specialization constant but can be extended to handle barriers or other functionalities.
+
+## Revisions
+
+v1:
+
+    * Initial proposal
+
+## `sycl::kernel_handler`
+
+The `sycl::kernel_handler` is a non-user constructible class only passed to user as an argument of the functor passed to `handler::parallel_for` and `handler::parallel_for_work_group`.
+
+```cpp
+namespace sycl {
+class kernel_handler {
+private:
+  kernel_handler();
+
+public:
+
+  // Return the value associate with the specialization constant id `s`.
+  // The value returned is either the 
+  template<class T, specialization_id<T>& s>
+  T get_specialization_constant();
+
+  template<auto& s>
+  typename std::remove_reference_t<decltype(s)>::type get_specialization_constant();
+
+};
+}
+```
+
+## Update `sycl::handler` class definition
+
+Functor passed to `sycl::handler::single_task`, `sycl::handler::parallel_for` and `sycl::handler::parallel_for_work_group` can take an extra `sycl::kernel_handler` as extra by-value argument.
+
+Below is an example of invoking a SYCL kernel function with `single_task`:
+
+```cpp
+myQueue.submit([&](handler & cgh) {
+  cgh.single_task<class myKernel>([=] () {});
+});
+```
+
+or
+
+```cpp
+myQueue.submit([&](handler & cgh) {
+  cgh.single_task<class myKernel>([=] (sycl::kernel_handler h) {});
+});
+```
+
+Below is an example of invoking a SYCL kernel function with `parallel_for`:
+
+```cpp
+myQueue.submit([&](handler & cgh) {
+  cgh.parallel_for<class myKernel>(range<1>(numWorkItems),
+  [=] (id<1> index) {});
+});
+```
+
+or
+
+```cpp
+myQueue.submit([&](handler & cgh) {
+  cgh.parallel_for<class myKernel>(range<1>(numWorkItems),
+  [=] (id<1> index, sycl::kernel_handler h) {});
+});
+```

--- a/proposals/sycl_modules.md
+++ b/proposals/sycl_modules.md
@@ -960,8 +960,8 @@ void do_conv(buffer<float, 2> in, buffer<float, 2> out) {
     auto in_acc = in.get_access<access::mode::read>(cgh);
     auto out_acc = out.get_access<access::mode::write>(cgh);
 
-    // Create a specialization constant placeholder.
-    specialization_constant<coeff_t, coeff_id> coeff =
+    // Create a specialization constant placeholder (sycl::specialization_constant object).
+    auto coeff =
         cgh.set_specialization_constant<coeff_t, coeff_id>(get_coefficients());
 
     cgh.parallel_for<class Convolution>(

--- a/proposals/sycl_modules.md
+++ b/proposals/sycl_modules.md
@@ -742,12 +742,10 @@ specialized kernel.
 
 On the new, type-safe, module approach, specialization constants are 
 typically associated with SPIR-V module images but are not limited to such image.
-The specialization constant type is defined as an (experimental) general 
-SYCL type as below:
+The specialization constant type is defined as an general SYCL type as below:
 
 ```cpp
 namespace sycl {
-namespace experimental {
 
 template <typename T>
 class spec_id {
@@ -755,6 +753,7 @@ private:
   // Implementation defined constructor.
   spec_id(const spec_id&) = delete;
   spec_id(spec_id&&) = delete;
+
 
 public:
 
@@ -769,21 +768,22 @@ public:
 
 template <class T, spec_id<T>& s>
 class spec_constant {
-private:
-  // Implementation defined constructor.
-  spec_constant(/* Implementation defined */);
-  spec_constant(spec_constant&&) = delete;
-
 public:
   using type = T;
 
+  // Create an empty (invalid) spec constant.
+  // Remains invalid until initialized by a call
+  // to handler::set_spec_constant or
+  // to handler::get_spec_constant
+  spec_constant();
+
   spec_constant(const spec_constant&) = default;
+  spec_constant& operator=(const spec_constant&) = default;
 
   T get() const; // explicit access.
   operator T() const;  // implicit conversion.
 };
 
-}  // namespace experimental
 }  // namespace sycl
 ```
 
@@ -798,6 +798,7 @@ The user then uses references to this object to bind the `spec_constant` value t
 inject the real value of the specialization constant at runtime.
 For the module associated with the host device, and possibly any device with non native spec constant support, the value is carried by the `spec_constant` object it-self.
 For modules natively supporting specialization constant, implementations must guaranty the values returned by the usage of the spec_constant materialized into a constant.
+
 
 ### Setting the value of spec constant
 

--- a/proposals/sycl_modules.md
+++ b/proposals/sycl_modules.md
@@ -915,6 +915,8 @@ public:
 | `template<class T, spec_id<T>& s> spec_constant<T, s> set_spec_constant(T)` | Set the given value as the specialization constant value in the underlying module and returns a `spec_constant` handler usable in kernel. If the user specify to the handle a specific module to use, then the value given to `set_spec_constant` must match the the one used to build the module. In case of mismatch, the SYCL runtime raises an error. |
 | `template<class T, spec_id<T>& s> spec_constant<T, s> get_spec_constant()`  | Returns a `spec_constant` handler usable in kernel.                                                                                       |
 
+Only one call to `set_spec_constant` or `get_spec_constant` is allowed per spec_id and per command group scope.
+If more than one call per spec_id and per command group scope is made then an runtime exception is thrown.
 
 Note the value of the specialization constant depends on the module that is used,
 not on the placeholder object.


### PR DESCRIPTION
This patch extended the module proposal to add better support for spec constant.
It also introduce a different way to name spec constant values.
Spec constant are named by creating an object of type `spec_id` and can be manipulated using NTTP.